### PR TITLE
Add in warnings for missing production settings

### DIFF
--- a/deploy-application.js
+++ b/deploy-application.js
@@ -155,6 +155,15 @@ module.exports = (function() {
   async function deployApplication() {
     try {
       config.production = true;
+      if (!config.schedule || !config.schedule.always) {
+        log("WARN: Databot not configured for always running!");
+      }
+      if (!config.failOffline) {
+        log("WARN: Databot not configured to fail if host offline!");
+      }
+      if (!config.notifyList || !config.notifyList.length) {
+        log("WARN: No databot status notification emails configured!");
+      }
       const api = new TDXApi({tdxServer: config.authServerURL});
       await api.authenticate(config.applicationId, config.applicationSecret);
       const databotFileExists = await checkResourceExists(api, getDatabotFileId());

--- a/deploy-application.js
+++ b/deploy-application.js
@@ -123,9 +123,11 @@ module.exports = (function() {
         id: getDatabotInstanceId(),
         name: config.databotName || config.public.applicationTitle,
         overwriteExisting: getDatabotInstanceId(),
-        schedule: {always: true},
+        schedule: config.schedule,
         shareKeyId: config.applicationId,
         shareKeySecret: config.applicationSecret,
+        notifyList: config.notifyList,
+        failOffline: config.failOffline,
       }
     );
   }

--- a/server/settings.js
+++ b/server/settings.js
@@ -29,6 +29,8 @@ module.exports = (function(config) {
       "appPort": 8082,
       "authServerURL": "https://tdx.nqminds.com",
       "databotName": "minimal",
+      "failOffline": true,
+      "notifyList": ["ivan@nquiringminds.com"],
       "public": {
         "applicationTitle": "app minimal",
         "dateFormat": "HH:mm DD/MM/YYYY",
@@ -40,7 +42,11 @@ module.exports = (function(config) {
           "accessTokenTTL": 31622400,
         },
       },
-      production: true,
+      "production": true,
+      "schedule": {
+        always: true,
+        cron: "",
+      },
     },
   };
 


### PR DESCRIPTION
Adds warnings if you attempt to deploy a databot and it is missing the required settings to ensure that it will:

- Always be started by the TDX
- Auto-fail if the host falls over
- Notify someone on error